### PR TITLE
Avoid using Unicode ellipsis in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ data "aws_ami" "ecs_ami" {
 }
 
 module "app_ecs_cluster" {
-  source = "…/modules/aws-ecs-cluster"
+  source = "../modules/aws-ecs-cluster"
 
   name        = "app"
   environment = "prod"


### PR DESCRIPTION
The Unicode ellipsis is probably not going to be parse-able by
whichever relative file path parser is used to parse module sources.