### PR TITLE
Add a variable for list of aws security group ids to be passed in

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:e66fbea875bcb788b29b1b5f59142e8231961ec5
+  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:2f6321ed86ed79bfed23b04dd6dfdbe7bc943fdc
 
 jobs:
   terratest:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.23.8
+    rev: v1.24.0
     hooks:
       - id: golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ensure_pre_commit: .git/hooks/pre-commit ## Ensure pre-commit is installed
 
 .PHONY: pre_commit_tests
 pre_commit_tests: ensure_pre_commit ## Run pre-commit tests
-	pre-commit run --all-files
+	pre-commit run --all-files --show-diff-on-failure
 
 .PHONY: test
 test: pre_commit_tests

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform0
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| aws\_security\_group\_ids | A list of aws security group ids to launch resources in | `list(string)` | `[]` | no |
 | desired\_capacity | Desired instance count. | `string` | `2` | no |
 | environment | Environment tag. | `string` | n/a | yes |
 | image\_id | Amazon ECS-Optimized AMI. | `string` | n/a | yes |
@@ -70,6 +69,7 @@ Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform0
 | max\_size | Maxmimum instance count. | `string` | `2` | no |
 | min\_size | Minimum instance count. | `string` | `2` | no |
 | name | The ECS cluster name this will launching instances for. | `string` | n/a | yes |
+| security\_group\_ids | A list of aws security group ids to launch resources in | `list(string)` | `[]` | no |
 | subnet\_ids | A list of subnet IDs to launch resources in. | `list(string)` | n/a | yes |
 | use\_AmazonEC2ContainerServiceforEC2Role\_policy | Attaches the AWS managed AmazonEC2ContainerServiceforEC2Role policy to the ECS instance role. | `string` | `true` | no |
 | vpc\_id | The id of the VPC to launch resources in. | `any` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform0
 | max\_size | Maxmimum instance count. | `string` | `2` | no |
 | min\_size | Minimum instance count. | `string` | `2` | no |
 | name | The ECS cluster name this will launching instances for. | `string` | n/a | yes |
-| security\_group\_ids | A list of aws security group ids to launch resources in | `list(string)` | `[]` | no |
+| security\_group\_ids | A list of aws security group ids to define what a resource can reach on the network. | `list(string)` | `[]` | no |
 | subnet\_ids | A list of subnet IDs to launch resources in. | `list(string)` | n/a | yes |
 | use\_AmazonEC2ContainerServiceforEC2Role\_policy | Attaches the AWS managed AmazonEC2ContainerServiceforEC2Role policy to the ECS instance role. | `string` | `true` | no |
 | vpc\_id | The id of the VPC to launch resources in. | `any` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform0
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
 ## Providers
 
 | Name | Version |
@@ -55,7 +61,8 @@ Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform0
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
+| aws\_security\_group\_ids | A list of aws security group ids to launch resources in | `list(string)` | `[]` | no |
 | desired\_capacity | Desired instance count. | `string` | `2` | no |
 | environment | Environment tag. | `string` | n/a | yes |
 | image\_id | Amazon ECS-Optimized AMI. | `string` | n/a | yes |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -9,7 +9,7 @@ data "aws_ami" "ecs_ami" {
 }
 
 resource "aws_security_group" "test_group" {
-  name        = "test_group"
+  name        = var.test_name
   description = "creates a security group to test with"
   vpc_id      = module.vpc.vpc_id
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -8,6 +8,13 @@ data "aws_ami" "ecs_ami" {
   }
 }
 
+resource "aws_security_group" "test_group" {
+  name        = "test_group"
+  description = "creates a security group to test with"
+  vpc_id      = module.vpc.vpc_id
+}
+
+
 module "app_ecs_cluster" {
   source = "../../"
 
@@ -17,11 +24,12 @@ module "app_ecs_cluster" {
   image_id      = "${data.aws_ami.ecs_ami.image_id}"
   instance_type = "t2.micro"
 
-  vpc_id           = module.vpc.vpc_id
-  subnet_ids       = module.vpc.private_subnets
-  desired_capacity = 1
-  max_size         = 1
-  min_size         = 1
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.private_subnets
+  security_group_ids = [aws_security_group.test_group.id]
+  desired_capacity   = 1
+  max_size           = 1
+  min_size           = 1
 }
 
 module "vpc" {

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_launch_configuration" "main" {
   instance_type               = var.instance_type
   image_id                    = var.image_id
   associate_public_ip_address = false
-  security_groups             = [aws_security_group.main.id]
+  security_groups             = concat(var.aws_security_group_ids, [aws_security_group.main.id])
 
   root_block_device {
     volume_type = "standard"

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_launch_configuration" "main" {
   instance_type               = var.instance_type
   image_id                    = var.image_id
   associate_public_ip_address = false
-  security_groups             = concat(var.aws_security_group_ids, [aws_security_group.main.id])
+  security_groups             = concat(var.security_group_ids, [aws_security_group.main.id])
 
   root_block_device {
     volume_type = "standard"

--- a/variables.tf
+++ b/variables.tf
@@ -53,7 +53,7 @@ variable "use_AmazonEC2ContainerServiceforEC2Role_policy" {
 }
 
 variable "security_group_ids" {
-  description = "A list of aws security group ids to launch resources in"
+  description = "A list of aws security group ids to define what a resource can reach on the network."
   type        = list(string)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,7 @@ variable "use_AmazonEC2ContainerServiceforEC2Role_policy" {
   default     = true
 }
 
-variable "aws_security_group_ids" {
+variable "security_group_ids" {
   description = "A list of aws security group ids to launch resources in"
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -53,7 +53,7 @@ variable "use_AmazonEC2ContainerServiceforEC2Role_policy" {
 }
 
 variable "security_group_ids" {
-  description = "A list of aws security group ids to define what a resource can reach on the network."
+  description = "A list of security group ids to attach to the autoscaling group"
   type        = list(string)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -52,3 +52,8 @@ variable "use_AmazonEC2ContainerServiceforEC2Role_policy" {
   default     = true
 }
 
+variable "aws_security_group_ids" {
+  description = "A list of aws security group ids to launch resources in"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Satisfies Issue #30.

Changes include
- creating a non-required variable called `security_group_ids`
- this variable will be passed to `aws_launch_configuration.main.security_groups` after adding the id of the new security group created in the same file
- tests passing an id to the new variable
- bumps pre-commit golang-cint library from `23.8` to `24.0`
- update `circleci_docker_primary` image with most updated one