### PR TITLE
pin aws provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform0
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
+| aws | ~> 2.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.70 |
 
 ## Inputs
 

--- a/examples/simple/providers.tf
+++ b/examples/simple/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  version = "~> 2.70"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,8 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws = "~> 2.70"
+  }
 }


### PR DESCRIPTION
[Pivotal Story](https://www.pivotaltracker.com/story/show/174129036)
Terratest (or maybe terraform) implicitly chooses the version of a provider to use if its not declared when a test is run. So if an AWS resource is used it will download the latest version of the AWS provider and use it.

This is causing issues in terratest so we need to pin the aws provider version