### PR TITLE
loosen tf versioning requirements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ module "app_ecs_cluster" {
   image_id      = "${data.aws_ami.ecs_ami.image_id}"
   instance_type = "t2.micro"
 
+  vpc_id           = "${module.vpc.id}"
   subnet_ids       = "${module.vpc.private_subnets}"
   desired_capacity = 3
   max_size         = 3
@@ -51,7 +52,7 @@ Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform0
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.13.0 |
+| terraform | >= 0.13.0 |
 | aws | ~> 3.0 |
 
 ## Providers

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -21,7 +21,7 @@ module "app_ecs_cluster" {
   name        = var.test_name
   environment = "test"
 
-  image_id      = "${data.aws_ami.ecs_ami.image_id}"
+  image_id      = data.aws_ami.ecs_ami.image_id
   instance_type = "t2.micro"
 
   vpc_id             = module.vpc.vpc_id

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = "~> 3.0"


### PR DESCRIPTION
This PR aims to loosen the versioning requirements so its consumers can use recent versions of terraform.