### PR TITLE
Address failing pre-commit and update things

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,19 +10,40 @@ repos:
         args:
           - --autofix
       - id: trailing-whitespace
+      - id: check-symlinks
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.16
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-gfm
+          - mdformat-toc
+        # mdformat fights with terraform_docs
+        exclude: README.m(ark)?d(own)?
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.32.2
     hooks:
       - id: markdownlint
 
+  - repo: https://github.com/detailyang/pre-commit-shell
+    rev: 1.0.5
+    hooks:
+      - id: shell-lint
+
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.76.0
     hooks:
       - id: terraform_docs
+        args:
+          - --args=--config=.terraform-docs.yml
       - id: terraform_fmt
 
   - repo: https://github.com/golangci/golangci-lint
     rev: v1.50.1
     hooks:
       - id: golangci-lint
+        entry: golangci-lint run --fix --timeout 300s

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,4 @@
+settings:
+  html: false
+  anchor: false
+formatter: "markdown table"

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform0
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| terraform | >= 0.13.0 |
+| aws | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| aws | ~> 4.0 |
 
 ## Modules
 
@@ -83,25 +83,25 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_desired_capacity"></a> [desired\_capacity](#input\_desired\_capacity) | Desired instance count. | `string` | `2` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | Environment tag. | `string` | n/a | yes |
-| <a name="input_image_id"></a> [image\_id](#input\_image\_id) | Amazon ECS-Optimized AMI. | `string` | n/a | yes |
-| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The instance type to use. | `string` | `"t2.micro"` | no |
-| <a name="input_max_size"></a> [max\_size](#input\_max\_size) | Maxmimum instance count. | `string` | `2` | no |
-| <a name="input_min_size"></a> [min\_size](#input\_min\_size) | Minimum instance count. | `string` | `2` | no |
-| <a name="input_name"></a> [name](#input\_name) | The ECS cluster name this will launching instances for. | `string` | n/a | yes |
-| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | A list of security group ids to attach to the autoscaling group | `list(string)` | `[]` | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs to launch resources in. | `list(string)` | n/a | yes |
-| <a name="input_use_AmazonEC2ContainerServiceforEC2Role_policy"></a> [use\_AmazonEC2ContainerServiceforEC2Role\_policy](#input\_use\_AmazonEC2ContainerServiceforEC2Role\_policy) | Attaches the AWS managed AmazonEC2ContainerServiceforEC2Role policy to the ECS instance role. | `string` | `true` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The id of the VPC to launch resources in. | `any` | n/a | yes |
+| desired\_capacity | Desired instance count. | `string` | `2` | no |
+| environment | Environment tag. | `string` | n/a | yes |
+| image\_id | Amazon ECS-Optimized AMI. | `string` | n/a | yes |
+| instance\_type | The instance type to use. | `string` | `"t2.micro"` | no |
+| max\_size | Maxmimum instance count. | `string` | `2` | no |
+| min\_size | Minimum instance count. | `string` | `2` | no |
+| name | The ECS cluster name this will launching instances for. | `string` | n/a | yes |
+| security\_group\_ids | A list of security group ids to attach to the autoscaling group | `list(string)` | `[]` | no |
+| subnet\_ids | A list of subnet IDs to launch resources in. | `list(string)` | n/a | yes |
+| use\_AmazonEC2ContainerServiceforEC2Role\_policy | Attaches the AWS managed AmazonEC2ContainerServiceforEC2Role policy to the ECS instance role. | `string` | `true` | no |
+| vpc\_id | The id of the VPC to launch resources in. | `any` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_ecs_cluster_arn"></a> [ecs\_cluster\_arn](#output\_ecs\_cluster\_arn) | The ARN of the ECS cluster. |
-| <a name="output_ecs_cluster_name"></a> [ecs\_cluster\_name](#output\_ecs\_cluster\_name) | The name of the ECS cluster. |
-| <a name="output_ecs_instance_role"></a> [ecs\_instance\_role](#output\_ecs\_instance\_role) | The name of the ECS instance role. |
+| ecs\_cluster\_arn | The ARN of the ECS cluster. |
+| ecs\_cluster\_name | The name of the ECS cluster. |
+| ecs\_instance\_role | The name of the ECS instance role. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Developer Setup

--- a/main.tf
+++ b/main.tf
@@ -154,4 +154,3 @@ resource "aws_autoscaling_group" "main" {
     propagate_at_launch = true
   }
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,4 +12,3 @@ output "ecs_instance_role" {
   description = "The name of the ECS instance role."
   value       = aws_iam_role.ecs_instance_role.name
 }
-


### PR DESCRIPTION
This should address [this](https://github.com/trussworks/terraform-aws-ecs-cluster/actions/runs/3395125675/jobs/5644594422) as well as brings in our preferred pre-commit things, and as a result, formats accordingly.