### PR TITLE
ci: removing PR limit from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,11 @@
 {
   "extends": [
-    "config:base",
-    ":disableDependencyDashboard"
+    "config:base"
   ],
   "labels": [
     "dependencies"
   ],
   "packageRules": [
-    {
-      "automerge": true,
-      "description": "Automerge all updates except major versions",
-      "matchUpdateTypes": [
-        "patch",
-        "pin",
-        "digest",
-        "minor"
-      ]
-    },
     {
       "description": "Tag the waddlers Github Team for major updates",
       "matchUpdateTypes": [
@@ -30,16 +19,11 @@
       "automerge": true,
       "description": "Group minor and patch updates into a single PR",
       "groupName": "dependencies",
-      "managers": [
-        "terraform",
-        "pre-commit",
-        "dockerfile",
-        "github-actions",
-        "gomod"
-      ],
       "matchUpdateTypes": [
         "minor",
-        "patch"
+        "patch",
+        "pin",
+        "digest"
       ]
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -34,7 +34,8 @@
         "terraform",
         "pre-commit",
         "dockerfile",
-        "github-actions"
+        "github-actions",
+        "gomod"
       ],
       "matchUpdateTypes": [
         "minor",
@@ -42,7 +43,6 @@
       ]
     }
   ],
-  "prConcurrentLimit": 2,
   "schedule": [
     "every weekend"
   ],


### PR DESCRIPTION
Removes PR limit from renovate to allow it to open as many PRs as it needs to.
